### PR TITLE
Ehrbase fixes develop auth

### DIFF
--- a/SmICSCoreLib/Factories/AQLCatalog.cs
+++ b/SmICSCoreLib/Factories/AQLCatalog.cs
@@ -51,7 +51,7 @@ namespace SmICSCoreLib.Factories
                                 OR NOT EXISTS h/data[at0001]/items[at0005]/value/value)
                                 AND o/items[at0024]/value/defining_code/code_string = '{ parameter.Departement }' 
                                 AND l/items[at0027]/value/value = '{ parameter.WardID }' 
-                                ORDER BY h/data[at0001]/items[at0004]/value/value");
+                                ORDER BY h/data[at0001]/items[at0004]/value/value ASC");
         }
         public static AQLQuery ContactPatients_WithoutWardInformation(ContactPatientsParameter parameter)
         {

--- a/SmICSCoreLib/Factories/ContactNetwork/ContactNetworkFactory.cs
+++ b/SmICSCoreLib/Factories/ContactNetwork/ContactNetworkFactory.cs
@@ -66,7 +66,7 @@ namespace SmICSCoreLib.Factories.ContactNetwork
             ContactParameter parameter = patientStack.Pop();
             List<PatientWardModel> patientWardList = RestDataAccess.AQLQuery<PatientWardModel>(AQLCatalog.ContactPatientWards(parameter));
 
-            if (patientWardList is null)
+            if (patientWardList is null || patientWardList.Count == 0)
             {
                 _logger.LogDebug("ContactNetworkFactory.FindWardsQuery(): Found No Wards - ResultSet: NULL");
                 return;

--- a/SmICSCoreLib/Factories/EpiCurve/EpiCurveFactory.cs
+++ b/SmICSCoreLib/Factories/EpiCurve/EpiCurveFactory.cs
@@ -62,7 +62,7 @@ namespace SmICSCoreLib.Factories.EpiCurve
             _logger.LogDebug("Flag - Query Paramters: Datum: {Date} \r PathogenList: {pathogens}", date.ToString(), parameter.PathogenCodesToAqlMatchString());
             List<FlagTimeModel> flagTimes = RestDataAccess.AQLQuery<FlagTimeModel>(AQLCatalog.LaborEpiCurve(date, parameter));
 
-            if (flagTimes == null)
+            if (flagTimes == null || flagTimes.Count == 0)
             {
                 AddToEpiCurveToSortedDict(date);
                 return;
@@ -87,7 +87,7 @@ namespace SmICSCoreLib.Factories.EpiCurve
                 List<PatientLocation> patientLocations = RestDataAccess.AQLQuery<PatientLocation>(AQLCatalog.PatientLocation(flag.Datum, flag.PatientID));
 
                 PatientLocation patientLocation = null;
-                if (patientLocations == null)
+                if (patientLocations == null || patientLocatations.Count == 0)
                 {
                     _logger.LogDebug("PatientLocation - Query Response Count: {LocationCount}", null);
                     patientLocation = new PatientLocation() { Ward = "ohne Stationsangabe", Departement = "0000" };

--- a/SmICSCoreLib/Factories/EpiCurve/EpiCurveFactory.cs
+++ b/SmICSCoreLib/Factories/EpiCurve/EpiCurveFactory.cs
@@ -87,7 +87,7 @@ namespace SmICSCoreLib.Factories.EpiCurve
                 List<PatientLocation> patientLocations = RestDataAccess.AQLQuery<PatientLocation>(AQLCatalog.PatientLocation(flag.Datum, flag.PatientID));
 
                 PatientLocation patientLocation = null;
-                if (patientLocations == null || patientLocatations.Count == 0)
+                if (patientLocations == null || patientLocations.Count == 0)
                 {
                     _logger.LogDebug("PatientLocation - Query Response Count: {LocationCount}", null);
                     patientLocation = new PatientLocation() { Ward = "ohne Stationsangabe", Departement = "0000" };

--- a/SmICSCoreLib/Factories/PatientMovement/PatientMovementFactory.cs
+++ b/SmICSCoreLib/Factories/PatientMovement/PatientMovementFactory.cs
@@ -3,6 +3,7 @@ using SmICSCoreLib.Factories.General;
 using SmICSCoreLib.Factories.PatientMovement.ReceiveModels;
 using SmICSCoreLib.REST;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 
@@ -71,7 +72,7 @@ namespace SmICSCoreLib.Factories.PatientMovement
                 transformToPatientMovementData(patientStay, episodeOfCare, patientMovementList);
             }
 
-            return patientMovementList;
+            return patientMovementList.Distinct().ToList();
         }
 
         private void transformToPatientMovementData(PatientStayModel patientStay, EpisodeOfCareModel episodeOfCare, List<PatientMovementModel> patientMovementList)

--- a/SmICSCoreLib/Factories/PatientMovement/PatientMovementFactory.cs
+++ b/SmICSCoreLib/Factories/PatientMovement/PatientMovementFactory.cs
@@ -56,7 +56,7 @@ namespace SmICSCoreLib.Factories.PatientMovement
 
                     List<EpisodeOfCareModel> episodeOfCareList = RestDataAccess.AQLQuery<EpisodeOfCareModel>(AQLCatalog.PatientAdmission(episodeOfCareParam));
                     List<EpisodeOfCareModel> discharges = RestDataAccess.AQLQuery<EpisodeOfCareModel>(AQLCatalog.PatientDischarge(episodeOfCareParam));
-                    if (!(episodeOfCareList is null))
+                    if (!(episodeOfCareList is null) && episodeOfCareList.Count > 0)
                     {
                         //result.First because there can be just one admission/discharge timestamp for each case
                         episodeOfCare = episodeOfCareList[0];

--- a/SmICSCoreLib/Factories/PatientMovement/PatientMovementModel.cs
+++ b/SmICSCoreLib/Factories/PatientMovement/PatientMovementModel.cs
@@ -52,5 +52,29 @@ namespace SmICSCoreLib.Factories.PatientMovement
            BewegungstypID = typeID;
            Bewegungstyp = typeName;
         }
+
+	// override object.Equals
+        public override bool Equals(object obj)
+        {
+            //
+            // See the full list of guidelines at
+            //   http://go.microsoft.com/fwlink/?LinkID=85237
+            // and also the guidance for operator== at
+            //   http://go.microsoft.com/fwlink/?LinkId=85238
+            //
+
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            PatientMovementModel other = (PatientMovementModel) obj;
+            return JsonConvert.SerializeObject(this).Equals(JsonConvert.SerializeObject(other));
+        }
+
+	public override int GetHashCode()
+        {
+            return JsonConvert.SerializeObject(this).GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
# Fixes for installation with EHRbase

More more detail, please refer to my e-mail to the SmICS development team. This PR targets develop_auth, i.e. the version with authentication that may lag behind cosurv_develop.

## Add tests for missing count in tests for empty lists

In the following factories, there are missing tests for
the count of a list in the if-statements meant to ensure
that empty lists are not accessed. In three locations, the
result from the AQL query was not testes for `Count != 0`,
so that non-existent list elements were queried downstream,
leading to crashes.

## Filter distinct the list of patient movements

The list of patient movements, in PatientMovementPs, that
is returned by EHRbase using the provided test data may in some
scenarios return wholly duplicate elements. This is rejected by the
data parser within SmICSVisualisierung. Since entirely duplicate
elements do not add information, they can be filtered in the backend,
before returning data to SmICSVisualisierung.

This implementation leverages LINQ's `Distinct()` operation, which
uses the provided equality comparator. To have a simple implementation
for `Equals` and `GetHashCode`, the serialization to JSON can be
employed - if the JSON of two instances of `PatientMovementModel` is
identical, the instances will be equal also.

## Workaround for EHRbase AQL bug

The EHRbase currently has a bug in the AQL parser, where the sort order
(`ASC`, `DSC`, `ASCENDING` or `DESCENDING`) is non-optional:
ehrbase/ehrbase#689

The AQL spec states that an ascending sort order is implied if not
otherwise specified, so this is clearly a bug in the EHRbase.

This bug leads to the rejection of the AQLQuery for the contact network.
By adding an explicit `ASC` sort to the respective AQL query, the issue
can be circumvented. Being more explicit should not impact compatibility
with the Better platform, so that the workaround should be permanently
in-place.